### PR TITLE
Screen Equality

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@
       height: 100vh;
     }
     #app{
-      height: 100vh;
+      min-height: 100vh;
       display: flex;
       flex-direction: column;
     }

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="viz_container">
     <LoadingScreen
       v-if="!isInternetExplorer"
       :is-loading="isLoading"
@@ -13,50 +13,53 @@
       </div>
     </div>
     <InternetExplorerPage v-if="isInternetExplorer" />
-    <div
-      v-if="!isInternetExplorer"
-      id="mapContainer"
-    >
-      <div id="map-section">
-        <MglMap
-          id="mapgl"
-          :container="container"
-          :map-style="mapStyle"
-          :zoom="zoom"
-          :min-zoom="minZoom"
-          :max-zoom="maxZoom"
-          :center="center"
-          :pitch="pitch"
-          :bearing="bearing"
-          :pitch-with-rotate="false"
-          :drag-rotate="false"
-          :touch-zoom-rotate="false"
-          :max-bounds="maxBounds"
-          @load="onMapLoaded"
-        >
-          <MglAttributionControl
-            position="bottom-right"
-            :compact="false"
-            custom-attribution="© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
-          />
+    <div id="viz_sections">
+      <div
+        v-if="!isInternetExplorer"
+        id="mapContainer"
+      >
+        <div id="map-section">
+          <MglMap
+            id="mapgl"
+            :container="container"
+            :map-style="mapStyle"
+            :zoom="zoom"
+            :min-zoom="minZoom"
+            :max-zoom="maxZoom"
+            :center="center"
+            :pitch="pitch"
+            :bearing="bearing"
+            :pitch-with-rotate="false"
+            :drag-rotate="false"
+            :touch-zoom-rotate="false"
+            :max-bounds="maxBounds"
+            @load="onMapLoaded"
+          >
+            <MglAttributionControl
+              position="bottom-right"
+              :compact="false"
+              custom-attribution="© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
+            />
 
-          <MglNavigationControl
-            position="top-right"
-            :show-compass="false"
-          />
-          <QuestionControl />
-          <MglScaleControl
-            position="bottom-right"
-            unit="imperial"
-          />
-          <MglFullscreenControl position="bottom-right" />
-          <MglGeolocateControl position="bottom-right" />
-        </MglMap>
+            <MglNavigationControl
+              position="top-right"
+              :show-compass="false"
+            />
+            <QuestionControl />
+            <MglScaleControl
+              position="bottom-right"
+              unit="imperial"
+            />
+            <MglFullscreenControl position="bottom-right" />
+            <MglGeolocateControl position="bottom-right" />
+          </MglMap>
+        </div>
       </div>
       <div id="story-section">
         <StoryBoard />
       </div>
     </div>
+    
     <!--The next div contains information to show the current zoom level of the map. This will only show on the
           development version of the application. To find the code controlling this, search for 'zoom level display' -->
     <div id="zoom-level-div" />
@@ -296,19 +299,33 @@
       color: #fff;
     }
   }
+  #viz_container {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+  #viz_sections{
+    flex: 1;
+    display: flex;
+    /*Stops Story Section from being full heigh tot show all of its content*/
+    max-height: 79vh;
+  }
   #mapContainer {
     position: relative;
     min-height: 200px;
-    max-height: 1080px;
     display: flex;
+    flex: 3;
     #map-section {
-      flex: 3;
-    }
-    #story-section {
       flex: 1;
-      overflow-y: auto;
     }
   }
+  #story-section {
+      display: flex;
+      flex: 1;
+      min-height: 100px;
+      overflow: hidden;
+      background: #fafafa;
+    }
 </style>
 
 

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="story-chapters-container">
-    <div
+      <div id="chapters">
+        <div
       v-for="chapter in mapStory.chapters"
       :key="chapter.id"
       class="features"
@@ -40,6 +41,7 @@
         </div>
       </section>
     </div>
+      </div>
   </div>
 </template>
 <script>
@@ -139,8 +141,8 @@
                 });
                 function animateCircle(layer, feature){
                   let markerColor = map.getPaintProperty(layer, 'circle-color');
-                  let popup = new mapboxgl.Popup({
-                      closeOnClick: false,
+                  let popup = new mapboxgl.Popup({ 
+                      closeOnClick: false, 
                       closeButton: false
                     }
                   ).setText(feature.properties.site_id);
@@ -166,14 +168,30 @@
                     element.parentNode.removeChild(element);
                   })
                 }
-            }
+            },
         }
     };
 </script>
 <style scoped lang="scss">
+
+  #story-chapters-container{
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #chapters{
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    /* for Firefox */
+    min-height: 0;
+  }
+
   .features {
     font-family: sans-serif;
-    background-color: #fafafa;
+    flex-grow: 1;
 
     section {
       padding: 25px 50px;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
Did a little rearrangment of the HTML and CSS to create what I think is a better screen to screen situation than what we currently have.

A few highlights:

Added a viz_section to house the map container and the story board as having the story board share the map container was having odd CSS effects when I was trying to do things.  Also creates a more mental consumptive situation, as the map is in map container and the story in the story div.  At least to me.

Added a chapters div to the storyborad.vue to create a parent to handle the scrolling function.  Was having mixed results until I created it.  Feel like it still flows as chapters div contains the features aka the chapters.  Idk let me know if you disagree.

Lastly for whatever reason the viz_container was removed along with its CSS.  It was the one playing along with the App.vue flexbox command so odd stuff was happening.  Adding it back in creates that sweet adapting layout we have for WBEEP.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial