### PR TITLE
removed timer and allowed flyto to finish

### DIFF
--- a/src/assets/monitoring_locations/delawareBasinCameraLocations.js
+++ b/src/assets/monitoring_locations/delawareBasinCameraLocations.js
@@ -21,7 +21,7 @@ export default {
                       ],
                       "zoom": 8,
                       "pitch": 90,
-                      "speed": 0.2,
+                      "speed":  0.1,
                       "curve": 1,
                       "essential": true
                    },
@@ -50,7 +50,7 @@ export default {
                         "center": [-74.6019444, 41.4411111],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -76,7 +76,7 @@ export default {
                         "center": [-74.6975, 41.37055556],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -102,7 +102,7 @@ export default {
                         "center": [-74.79527778, 41.30916667],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -128,7 +128,7 @@ export default {
                         "center": [-75.0825, 40.82638889],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -154,7 +154,7 @@ export default {
                         "center": [-75.99826819, 40.5225932],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -180,7 +180,7 @@ export default {
                         "center": [-74.94888889, 40.3647222],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -206,7 +206,7 @@ export default {
                         "center": [-74.7780556, 40.22166667],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -232,7 +232,7 @@ export default {
                         "center": [-74.9568342, 40.1739982],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -261,7 +261,7 @@ export default {
                       ],
                       "zoom": 8,
                       "pitch": 90,
-                      "speed": 0.2,
+                      "speed":  0.1,
                       "curve": 1,
                       "essential": true
                    },
@@ -290,7 +290,7 @@ export default {
                         "center": [-75.5932623, 39.8698328],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },
@@ -316,7 +316,7 @@ export default {
                         "center": [-75.6365, 39.76280556],
                         "zoom": 8,
                         "pitch": 90,
-                        "speed": 0.2,
+                        "speed":  0.1,
                         "curve": 1,
                         "essential": true
                     },

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -163,7 +163,6 @@
                 let self = this; // create an 'alias' for 'this', so that we can access 'this' inside deeper scopes
                 self.isTourRunning = true;
                 let map = this.$store.map;
-                let interval = 1000;
                 let promise = Promise.resolve();
                 let locationsInTour = self.getLocationsInTour(tourType);
                 let remainingLocations = locationsInTour.length;
@@ -181,7 +180,9 @@
                                       self.removeElements(document.querySelectorAll(".mapboxgl-popup"));
                                   }, 3000);
                               }
-                              setTimeout(resolve, interval);
+                              map.on('moveend', function (e) {
+                                  resolve('end of flyTo')
+                              });
                           });
                       });
                 });


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Removed Timed End and to Allow FlyTo to finish
-----------
I think this is a significant improvement. Found it while trying to figure out how to pause the tours. The summary is I removed the code that set a time before each promise would run for code that runs when the map stops moving, so at the end of one flyTo. This allows us to fully control the flyTo with the 'options' and not have to work around the set time delay. 

Small code change, but wanted to get it in the code, so that we could take advantage of it while styling the tours. 

Oh, I also messed around with the 'cameras' tour timing just to make sure it did what I thought. 

And note to self - restart the server if you want to be sure to see effects from changing the JSON


After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial