### PR TITLE
Delaware mini viz 361 pause tour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Change to allow user to pause a tour
 - Text Bubble Popups
 - Loading Screen Text Change
 - Dynamic Icons for the All Gages Tour

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -203,7 +203,7 @@
 
                 // Fly to the locations on the tour list
                 locationsInTour.forEach(function(feature) {
-                      promise = promise.then(function () {
+                      promise = promise.then(function() {
                           remainingLocations = remainingLocations - 1;
                           map.flyTo(feature.properties.flyToCommands);
                           self.addCustomMarker(tourType, feature);

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -36,8 +36,8 @@
               take a tour
             </button>
             <button
-              v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
-              @click="runTour(chapter.tourType)"
+                v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
+                @click="runTour(chapter.tourType)"
             >
               resume tour
             </button>
@@ -45,8 +45,8 @@
               Tour is Running
             </button>
             <button
-              v-show="chapter.extendedContent && isTourRunning"
-              @click="pauseTour"
+                v-show="chapter.extendedContent && isTourRunning"
+                @click="pauseTour"
             >
               Pause the tour
             </button>
@@ -198,7 +198,7 @@
                           map.flyTo(feature.properties.flyToCommands);
                           self.addCustomMarker(tourType, feature);
                           return new Promise(function (resolve, reject) {
-                              if (self.isTourPauseActive) {
+                              if (self.isTourPauseActive) { // If has pressed the pause button, reject the promise and break the promise chain
                                   self.indexOfPausedTour = index; // Save the index so we can restart the tour at the same place
                                   reject('user paused tour');
                               }
@@ -216,8 +216,7 @@
                           });
                       });
 
-                      promise.catch(error => {
-                          console.log(error);
+                      promise.catch(function() {   // When the pause button is pressed, reset the tour so it can be resumed or restarted.
                           self.isTourPauseActive = false;
                           self.isTourRunning = false;
                       });

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -198,8 +198,8 @@
                           map.flyTo(feature.properties.flyToCommands);
                           self.addCustomMarker(tourType, feature);
                           return new Promise(function (resolve, reject) {
-                              if (self.isTourPauseActive) { // If has pressed the pause button, reject the promise and break the promise chain
-                                  self.indexOfPausedTour = index; // Save the index so we can restart the tour at the same place
+                              if (self.isTourPauseActive) { // If user has pressed the pause button, reject the promise and break the promise chain
+                                  self.indexOfPausedTour = index; // Save the index so we can resume the tour at the same place
                                   reject('user paused tour');
                               }
 

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -36,8 +36,8 @@
               take a tour
             </button>
             <button
-                v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
-                @click="runTour(chapter.tourType)"
+              v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
+              @click="runTour(chapter.tourType)"
             >
               resume tour
             </button>
@@ -45,8 +45,8 @@
               Tour is Running
             </button>
             <button
-                v-show="chapter.extendedContent && isTourRunning"
-                @click="pauseTour"
+              v-show="chapter.extendedContent && isTourRunning"
+              @click="pauseTour"
             >
               Pause the tour
             </button>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Allow User to Pause Tour
-----------
Made changes to allow user to pause tour

Description
-----------
This change opens the door to a bunch of fringe use case weirdness. I attempted to cover the main use cases I could image. I also left all the tour buttons active so that we could test out a wider range of things a user may do to mess up our well oiled application. I didn't address the 'aesthetic appeal or ergonomics' of the buttons to pause the tour. I just wanted to get the base functionality running and 'user' tested before digging into the surface details.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial