### PR TITLE
Delaware mini viz 362 accept new location types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added change to prevent error from location type without icon associated
 - Change to allow user to pause a tour
 - Text Bubble Popups
 - Loading Screen Text Change

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -36,8 +36,8 @@
               take a tour
             </button>
             <button
-                v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
-                @click="runTour(chapter.tourType)"
+              v-show="chapter.extendedContent && !isTourRunning && indexOfPausedTour > 0"
+              @click="runTour(chapter.tourType)"
             >
               resume tour
             </button>
@@ -45,8 +45,8 @@
               Tour is Running
             </button>
             <button
-                v-show="chapter.extendedContent && isTourRunning"
-                @click="pauseTour"
+              v-show="chapter.extendedContent && isTourRunning"
+              @click="pauseTour"
             >
               Pause the tour
             </button>
@@ -164,11 +164,17 @@
                   }
                 });
                 //Create Dynamic Icons based on the filtered object keys
-                filtered.forEach(function(d){
-                  //Need this for webpack to find the icons
-                  let iconURL = require('../images/icons/PNG/COLORED/' + d + '.png');
-                  //icons stores the multiple img tags to be fed to the popup
-                  icons += "<img src='" + iconURL + "'/> ";
+                filtered.forEach(function(iconName){
+                  try {
+                      let iconURL = require('../images/icons/PNG/COLORED/' + iconName + '.png');
+                      //icons stores the multiple img tags to be fed to the popup
+                      icons += "<img src='" + iconURL + "'/> ";
+                  }
+                  catch (error) {
+                      console.log('Warning: there has been a problem adding the popup icons. Perhaps you have a property ' +
+                              'in the monitoring location JSON that has a value of true, but does not have a matching' +
+                              ' icon available.')
+                  }
                 });
                 
                 layer !== 'all_locations' ? popup.setText(feature.properties.site_id) : popup.setHTML('<div>' + feature.properties.site_id + '</div><div id="iconContainer">' + icons +'</div>');


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Fix to Stop Errors From Location Types Without Associated Icons
-----------
This is a little fix to prevent the Webpack require from not finding what expects to find.

Description
-----------
When adding any 'properties' to the monitoring location JSON files that have a value of true, Webpack expected to find an icon that was associated with it. This will not always be the case, so I added a 'catch' that will grab up any mistakes that happen. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial