### PR TITLE
Fix text chapter highlighting/enable map operations on text chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed bug in text-overlay chapter that prevented chapter highlighting and map operations
 - Switched to using a 'master' monitoring location file.
 - D3 Rings
 - Add demo text chapter

--- a/src/components/StoryBoard.vue
+++ b/src/components/StoryBoard.vue
@@ -13,8 +13,8 @@
         >
           <div
             v-show="!isTourRunning"
-            @click="chapter.isText ? toggleTextOverlay(state='on', chapter.html) : (moveToLocation(chapter.flyToCommands, chapter.id), toggleLayerVisibility(chapter.id, chapter.layersToHide, chapter.hiddenLayersToShow), toggleTextOverlay(state='off', null), addMonitoringLocationRings(chapter.D3Rings))"
-            @mouseover="chapter.isText ? toggleTextOverlay(state='on', chapter.html) : (moveToLocation(chapter.flyToCommands, chapter.id), toggleLayerVisibility(chapter.id, chapter.layersToHide, chapter.hiddenLayersToShow), toggleTextOverlay(state='off', null), addMonitoringLocationRings(chapter.D3Rings))"
+            @click="moveToLocation(chapter.flyToCommands, chapter.id), toggleLayerVisibility(chapter.id, chapter.layersToHide, chapter.hiddenLayersToShow), addMonitoringLocationRings(chapter.D3Rings), chapter.isText ? toggleTextOverlay(state='on', chapter.html) : toggleTextOverlay(state='off', null)"
+            @mouseover="moveToLocation(chapter.flyToCommands, chapter.id), toggleLayerVisibility(chapter.id, chapter.layersToHide, chapter.hiddenLayersToShow), addMonitoringLocationRings(chapter.D3Rings), chapter.isText ? toggleTextOverlay(state='on', chapter.html) : toggleTextOverlay(state='off', null)"
           >
             <h3>{{ chapter.title }}</h3>
             <p>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Text Chapter Bug Fix
-----------
Fix bugs with text-overlay chapters.

Description
-----------
Enable layer and fly operations on text-overlay chapters to support staging the map in the background for subsequent chapters.
Fix text chapter highlighting in story div.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial